### PR TITLE
next_time Etorbi::EoTime object to UTC time

### DIFF
--- a/lib/rufus/scheduler/cronline/occurrences.rb
+++ b/lib/rufus/scheduler/cronline/occurrences.rb
@@ -5,11 +5,11 @@ class Rufus::Scheduler
 
     def occurrences(time0, time1)
       ret = []
-      nt = time0
+      nt = time0.utc
 
       loop do
-        nt = next_time(nt)
-        break if time1 < nt
+        nt = next_time(nt).utc
+        break if time1.utc < nt
         ret << nt
       end
 

--- a/rufus-scheduler-cronline-occurrences.gemspec
+++ b/rufus-scheduler-cronline-occurrences.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'rufus-scheduler', "~> 3.0"
+  spec.add_runtime_dependency 'rufus-scheduler', "~> 3.4"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Since rufus-scheduler v3.4.0, `Rufus:: Scheduler::Job#next_time` method return `Etorbi::EoTime` object.

This PR has been modified to convert `Etorbi::EoTime` object to UTC time.